### PR TITLE
remove unused "mongodb" from TravisCI "services"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
   - "0.10"
-services: mongodb


### PR DESCRIPTION
I couldn't find where it was used.
